### PR TITLE
Refactor get_precision_recall_attrs call

### DIFF
--- a/From_Human_Pose_to_On_Body_Devices_for_Human_Activity_Recognition/LARA_dataset/metrics.py
+++ b/From_Human_Pose_to_On_Body_Devices_for_Human_Activity_Recognition/LARA_dataset/metrics.py
@@ -203,7 +203,7 @@ class Metrics(object):
 
         logging.info('            Metric:    Acc attr: \n{}'.format(acc_attrs))
 
-        precision_attr, recall_attr = self.get_precision_recall_attrs(targets, torch.round(predictions))
+        precision_attr, recall_attr = self.get_precision_recall(targets, torch.round(predictions))
         logging.info('            Metric:    Precision attr: \n{}'.format(precision_attr))
         logging.info('            Metric:    Recall attr: \n{}'.format(recall_attr))
         return


### PR DESCRIPTION
The old get_precision_recall_attrs() call is probably deprecated (does not exist anymore). Changed it to the current get_precision_recall(). Confirmed that it works now.